### PR TITLE
Commands: Documentation for word

### DIFF
--- a/Commands/Documentation for Word.tmCommand
+++ b/Commands/Documentation for Word.tmCommand
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>beforeRunningCommand</key>
+	<string>nop</string>
+	<key>command</key>
+	<string>#!/usr/bin/env bash
+[[ -f "${TM_SUPPORT_PATH}/lib/bash_init.sh" ]] &amp;&amp; . "${TM_SUPPORT_PATH}/lib/bash_init.sh"
+
+TERM=${TM_SELECTED_TEXT:-$TM_CURRENT_WORD}
+
+# A more clever solution would read the JSON at
+# http://docs.go-mono.com/monodoc.ashx?fsearch=$TERM
+if [ $TERM ]; then
+	echo "&lt;meta http-equiv='Refresh'
+	        content='0;URL=http://docs.go-mono.com/search.html#$TERM'&gt;"
+fi
+
+</string>
+	<key>input</key>
+	<string>selection</string>
+	<key>inputFormat</key>
+	<string>text</string>
+	<key>keyEquivalent</key>
+	<string>^h</string>
+	<key>name</key>
+	<string>Documentation for Word</string>
+	<key>outputCaret</key>
+	<string>afterOutput</string>
+	<key>outputFormat</key>
+	<string>html</string>
+	<key>outputLocation</key>
+	<string>newWindow</string>
+	<key>scope</key>
+	<string>source.cs</string>
+	<key>uuid</key>
+	<string>E4DA0B5D-2B4C-47F4-BC85-E823D664CD08</string>
+	<key>version</key>
+	<integer>2</integer>
+</dict>
+</plist>


### PR DESCRIPTION
This will look up the current selection / word via http://docs.go-mono.com

I could expand this but then we'd need to parse JSON.
