### PR TITLE
Fix string arguments to methods

### DIFF
--- a/Syntaxes/C#.tmLanguage
+++ b/Syntaxes/C#.tmLanguage
@@ -520,7 +520,7 @@
 				</dict>
 				<dict>
 					<key>begin</key>
-					<string>(?!new)(?=[\w&lt;].*\s+)(?=[^=]+\()</string>
+					<string>(?!new)(?=[\w&lt;][^=]*\s+[^=]+\()</string>
 					<key>end</key>
 					<string>(})|(?=;)</string>
 					<key>endCaptures</key>


### PR DESCRIPTION
From a fix for the same issue:
https://github.com/atom/language-csharp/commit/3ddd53a6971dfc59e05f4eafb
6b82f92f91db353
